### PR TITLE
Change wapuu archive page link protocol to https

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 わぷーアーカイブのための JSON API
 
-[わぷーアーカイブ](http://jawordpressorg.github.io/wapuu/)
+[わぷーアーカイブ](https://jawordpressorg.github.io/wapuu/)
 
 ## エンドポイント
 
@@ -48,7 +48,7 @@ https://jawordpressorg.github.io/wapuu-api/v1/wapuu.json
 2. [wapuu.csv](wapuu.csv) 内に追加したいわぷーの情報を入力する (JSON ファイルではなく、CSV ファイルを編集する) 。
 3. プルリクエストを送る。
 
-[Wapuu archive](http://jawordpressorg.github.io/wapuu/) のレポジトリに画像を追加するためのプルリクエストを送信する必要はありません。お持ちの GitHub アカウントのレポジトリや gist などに画像を配置し、そちらへの画像 URL を CSV ファイルに記述する URL として使用してください。
+[Wapuu archive](https://jawordpressorg.github.io/wapuu/) のレポジトリに画像を追加するためのプルリクエストを送信する必要はありません。お持ちの GitHub アカウントのレポジトリや gist などに画像を配置し、そちらへの画像 URL を CSV ファイルに記述する URL として使用してください。
 
 ## 質問など
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 JSON API for Wapuu in the World.
 
-[See more about Wapuu.](http://jawordpressorg.github.io/wapuu/)
+[See more about Wapuu.](https://jawordpressorg.github.io/wapuu/)
 
 ## Endpoint
 
@@ -48,7 +48,7 @@ https://jawordpressorg.github.io/wapuu-api/v1/wapuu.json
 2. Add your Wapuu information into [wapuu.csv](https://github.com/jawordpressorg/wapuu-api/blob/master/wapuu.csv). You don't need to edit the JSON file since the CI automattically creates it from the CSV file.
 3. Make a pull request in this repository.
 
-There's no need to send pull request for your Wapuu image to [Wapuu archive](http://jawordpressorg.github.io/wapuu/) repository, you should have your Wapuu image in your own GitHub repository. :smile:
+There's no need to send pull request for your Wapuu image to [Wapuu archive](https://jawordpressorg.github.io/wapuu/) repository, you should have your Wapuu image in your own GitHub repository. :smile:
 
 ## Issue or Question
 


### PR DESCRIPTION
The link of github pages in the readme was `http`, so I changed it to `https`.